### PR TITLE
Fix weird bug

### DIFF
--- a/orgimage.py
+++ b/orgimage.py
@@ -1934,6 +1934,7 @@ class OrgExtraImageShowErrorCommand(sublime_plugin.TextCommand):
         lines_refs.clear()
         panel.set_read_only(False)
         panel.erase(edit, Region(0, panel.size()))
+        [view.substr(r) for r in href_regions]
         for region in href_regions:
             url = view.substr(region)
             if url in error_refs:


### PR DESCRIPTION
Last night while changing the defaultTimeout to a value lower than 0.2 to testing, I unexpectedly discovered an unusual problem. The error output panel occasionally did not include the url of the first `orgmode.link.text.href ` region of the file.

![1](https://github.com/phhuyhoang/orgextended/assets/94783029/d0310da7-f2de-44aa-aafe-35dcc37ba814)

To investigate, I added debug variables to capture substrings at random positions, and the results left me puzzled.

```py
    href_regions = find_by_selector_in_region(
        view,
        region,
        SELECTOR_ORG_LINK_TEXT_HREF) 
    # [(2, 33), (44, 75), (80, 112), (117, 149), (154, 186), (191, 222), (227, 259), (264, 296), (301, 332), (338, 370), (375, 407)]
    checktype = [type(r) for r in href_regions] 
    # [<class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>, <class 'sublime.Region'>]
    temp1 = [view.substr(r) for r in href_regions]
    # ['https://i.imgur.com/HBaRG1I.png', 'https://i.imgur.com/WsxRdVG.jpg', 'https://i.imgur.com/jYPokL6.jpeg', 'https://i.imgur.com/fsbwkCK.jpeg', 'https://i.imgur.com/7QPdgXJ.jpeg', 'https://i.imgur.com/Wf9txJq.gif', 'https://i.imgur.com/Sy7hcNk.jpeg', 'https://i.imgur.com/SSYQSnc.jpeg', 'https://i.imgur.com/vSaroJw.png', 'https://i.imgur.com/U0M2u7S.jpeg', 'https://i.imgur.com/W8fPFSK.jpeg']
    number_of_lines = len(view.lines(Region(0, view.size())))
    pad_length = len(str(number_of_lines)) + 1
    panel_text = []

    if view.id() != panel_state['view_id']:
        panel_state['view_id'] = view.id()

    panel_state['change_id'] = change_id
    lines_refs.clear()
    panel.set_read_only(False)
    panel.erase(edit, Region(0, panel.size()))
    temp2 = [view.substr(r) for r in href_regions]
    # ['\x00', 'https://i.imgur.com/WsxRdVG.jpg', 'https://i.imgur.com/jYPokL6.jpeg', 'https://i.imgur.com/fsbwkCK.jpeg', 'https://i.imgur.com/7QPdgXJ.jpeg', 'https://i.imgur.com/Wf9txJq.gif', 'https://i.imgur.com/Sy7hcNk.jpeg', 'https://i.imgur.com/SSYQSnc.jpeg', 'https://i.imgur.com/vSaroJw.png', 'https://i.imgur.com/U0M2u7S.jpeg', 'https://i.imgur.com/W8fPFSK.jpeg']
    for region in href_regions:
        url = view.substr(region)
        if url in error_refs:
```

It's strange to read the same region from the same file but get two different strings.
Surprisingly, it fixes the bug as well:

![2](https://github.com/phhuyhoang/orgextended/assets/94783029/e9060972-5644-462d-80c7-567f56ac382b)

However, removing `temp2` brought the issue back. Upon inspecting the API of the `view.substr()` method, I was even more surprised to find that it did not recognize the first element of `href_regions` as a `Region` instance. This caused it to fallback to the second case, treating x as a `Point` and resulting in a string with length = 1, either `\x00` or some other unknown character.

```py
def substr(self, x):
    if isinstance(x, Region):
        return sublime_api.view_cached_substr(self.view_id, x.a, x.b)
    else:
        s = sublime_api.view_cached_substr(self.view_id, x, x + 1)
        # S2 backwards compat
        if len(s) == 0:
            return "\x00";
        else:
            return s
```

I suspect this is an internal bug within the core of Sublime. 
Nevertheless, I effortlessly fixed a weird bug using a weird solution, and it unexpectedly worked.